### PR TITLE
Set a target gray for auto exposure/autogain features

### DIFF
--- a/camera_base.orogen
+++ b/camera_base.orogen
@@ -10,7 +10,7 @@ import_types_from "camera_interface/CamTypes.h"
 
 task_context "Task" do
     needs_configuration
-    
+
     ###########################################################
     ########################ports##############################
     ###########################################################
@@ -52,6 +52,8 @@ task_context "Task" do
     	doc 'trigger mode of the camera, allowed values: freerun, fixed, sync_in1, none'
     property('channel_data_depth', 'int',8).
         doc 'bit depth per channel'
+    property('target_gray_value', 'int',128).dynamic
+        doc 'target average gray value for the auto exposure and auto gain features'
     property('exposure', 'int',5000).dynamic
     	doc 'exposure value if exposure mode is not auto'
     property('exposure_mode', 'string','auto').dynamic

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -291,6 +291,11 @@ bool Task::configureCamera()
         cam_interface->setAttrib(camera::int_attrib::BinningY,_binning_y);
     }
 
+    if (cam_interface->isAttribAvail(int_attrib::TargetGrayValue))
+    {
+        cam_interface->setAttrib(camera::int_attrib::TargetGrayValue, _target_gray_value);
+    }
+
     //setting ExposureValue
     if(cam_interface->isAttribAvail(int_attrib::ExposureValue))
         cam_interface->setAttrib(camera::int_attrib::ExposureValue,_exposure);
@@ -904,3 +909,14 @@ bool Task::setExposure_mode(std::string const& mode)
 
     return TaskBase::setExposure_mode(mode);
 }
+bool Task::setTarget_gray_value(boost::int32_t value)
+{
+    if (cam_interface->isAttribAvail(int_attrib::TargetGrayValue))
+    {
+        cam_interface->setAttrib(camera::int_attrib::TargetGrayValue, value);
+        return true;
+    }
+    else
+        return false;
+}
+

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -80,6 +80,7 @@ namespace camera_base {
 
       virtual bool setExposure(int exposure);
       virtual bool setExposure_mode(std::string const& value);
+      virtual bool setTarget_gray_value(boost::int32_t value);
 
     public:
         Task(std::string const& name = "camera::Task");


### PR DESCRIPTION
This allow to set a target average gray for the auto exposure and auto gain features. 

Depends on:
https://github.com/rock-drivers/drivers-camera_aravis/pull/6
https://github.com/rock-drivers/drivers-camera_interface/pull/2

Not dependent, but related:
https://github.com/rock-drivers/drivers-orogen-camera_aravis/pull/3