### PR TITLE
Added several dc1394 features

### DIFF
--- a/camera_base.orogen
+++ b/camera_base.orogen
@@ -74,6 +74,10 @@ task_context "Task" do
     	doc 'opening mode (Master, Monitor, MasterMulticast)'
     property('synchronize_time_interval', 'int',0).
     	doc 'time interval in micro seconds which is used to synchronize camera time with system time. 0 == no synchronization'
+	property('shutter_time', 'int',300).dynamic
+    	doc 'shutter time if shutter mode is not auto'
+    property('shutter_mode', 'string','auto').dynamic
+    	doc 'shutter mode (auto, manual)'
     property('whitebalance_mode', 'string','auto').
     	doc 'whitebalance mode (auto, manual, auto_once, none)'
     property('whitebalance_blue', 'int',100).

--- a/camera_base.orogen
+++ b/camera_base.orogen
@@ -54,6 +54,8 @@ task_context "Task" do
         doc 'bit depth per channel'
     property('target_gray_value', 'int',128).dynamic
         doc 'target average gray value for the auto exposure and auto gain features'
+    property('exposure_power', 'bool',true).
+    	doc 'turns exposure on or off'
     property('exposure', 'int',5000).dynamic
     	doc 'exposure value if exposure mode is not auto'
     property('exposure_mode', 'string','auto').dynamic
@@ -74,10 +76,24 @@ task_context "Task" do
     	doc 'opening mode (Master, Monitor, MasterMulticast)'
     property('synchronize_time_interval', 'int',0).
     	doc 'time interval in micro seconds which is used to synchronize camera time with system time. 0 == no synchronization'
-	property('shutter_time', 'int',300).dynamic
+    property('saturation_power', 'bool',true).
+    	doc 'turns saturation on or off'
+    property('saturation', 'int',300).dynamic
+    	doc 'saturation if saturation mode is not auto'
+    property('saturation_mode', 'string','auto').dynamic
+    	doc 'saturation mode (auto, manual)'
+    property('sharpness_power', 'bool',true).
+    	doc 'turns sharpness on or off'
+    property('sharpness', 'int',300).dynamic
+    	doc 'sharpness if sharpness mode is not auto'
+    property('sharpness_mode', 'string','auto').dynamic
+    	doc 'sharpness mode (auto, manual)'
+    property('shutter_time', 'int',300).dynamic
     	doc 'shutter time if shutter mode is not auto'
     property('shutter_mode', 'string','auto').dynamic
     	doc 'shutter mode (auto, manual)'
+    property('whitebalance_power', 'bool',true).
+    	doc 'turns whitebalance on or off'
     property('whitebalance_mode', 'string','auto').
     	doc 'whitebalance mode (auto, manual, auto_once, none)'
     property('whitebalance_blue', 'int',100).

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -313,6 +313,23 @@ bool Task::configureCamera()
       
     }
     
+	//setting gain mode
+    if(_gain_mode_auto.value() == true)
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::GainModeToAuto))
+            cam_interface->setAttrib(enum_attrib::GainModeToAuto);
+        else
+            RTT::log(RTT::Info) << "GainModeToAuto is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::GainModeToManual))
+            cam_interface->setAttrib(enum_attrib::GainModeToManual);
+        else
+            RTT::log(RTT::Info) << "GainModeToManual is not supported by the camera" << RTT::endlog();
+      
+    }
+    
     //setting _whitebalance_mode
     if(_whitebalance_mode.value() == "manual")
     {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -312,8 +312,8 @@ bool Task::configureCamera()
             RTT::log(RTT::Info) << "GammaToOff is not supported by the camera" << RTT::endlog();
       
     }
-    
-	//setting gain mode
+   
+    //setting gain mode
     if(_gain_mode_auto.value() == true)
     {
         if(cam_interface->isAttribAvail(enum_attrib::GainModeToAuto))
@@ -329,7 +329,24 @@ bool Task::configureCamera()
             RTT::log(RTT::Info) << "GainModeToManual is not supported by the camera" << RTT::endlog();
       
     }
-    
+
+    //setting Whitebalance to on/off
+    if(_whitebalance_power.get())
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::WhitebalToOn))
+            cam_interface->setAttrib(enum_attrib::WhitebalToOn);
+        else
+            RTT::log(RTT::Info) << "WhitebalToOn is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::WhitebalToOff))
+            cam_interface->setAttrib(enum_attrib::WhitebalToOff);
+        else
+            RTT::log(RTT::Info) << "WhitebalToOff is not supported by the camera" << RTT::endlog();
+      
+    }
+
     //setting _whitebalance_mode
     if(_whitebalance_mode.value() == "manual")
     {
@@ -363,6 +380,22 @@ bool Task::configureCamera()
         return false;
     }
 
+    //setting exposure on/off
+    if(_exposure_power.get())
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::ExposureToOn))
+            cam_interface->setAttrib(enum_attrib::ExposureToOn);
+        else
+            RTT::log(RTT::Info) << "ExposureToOn is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::ExposureToOff))
+            cam_interface->setAttrib(enum_attrib::ExposureToOff);
+        else
+            RTT::log(RTT::Info) << "ExposureToOff is not supported by the camera" << RTT::endlog();
+    }
+
     //setting _exposure_mode
     if(_exposure_mode.value() == "auto")
     {
@@ -392,6 +425,82 @@ bool Task::configureCamera()
     else
     {
         RTT::log(RTT::Error) << "Exposure mode "+ _exposure_mode.value() + " is not supported!" << RTT::endlog();
+        report(UNKOWN_PARAMETER);
+        return false;
+    }
+
+    //setting saturation on/off
+    if(_saturation_power.get())
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::SaturationToOn))
+            cam_interface->setAttrib(enum_attrib::SaturationToOn);
+        else
+            RTT::log(RTT::Info) << "SaturationToOn is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::SaturationToOff))
+            cam_interface->setAttrib(enum_attrib::SaturationToOff);
+        else
+            RTT::log(RTT::Info) << "SaturationToOff is not supported by the camera" << RTT::endlog();
+    }
+
+    //setting saturation mode
+    if(_saturation_mode.value() == "auto")
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::SaturationModeToAuto))
+            cam_interface->setAttrib(enum_attrib::SaturationModeToAuto);
+        else
+            RTT::log(RTT::Info) << "SaturationModeToAuto is not supported by the camera" << RTT::endlog();
+    }
+    else if(_saturation_mode.value() == "manual")
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::SaturationModeToManual))
+            cam_interface->setAttrib(enum_attrib::SaturationModeToManual);
+        else
+            RTT::log(RTT::Info) << "SaturationModeToManual is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        RTT::log(RTT::Error) << "Saturation mode "+ _saturation_mode.value() + " is not supported!" << RTT::endlog();
+        report(UNKOWN_PARAMETER);
+        return false;
+    }
+
+    //setting sharpness on/off
+    if(_sharpness_power.get())
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::SharpnessToOn))
+            cam_interface->setAttrib(enum_attrib::SharpnessToOn);
+        else
+            RTT::log(RTT::Info) << "SharpnessToOn is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::SharpnessToOff))
+            cam_interface->setAttrib(enum_attrib::SharpnessToOff);
+        else
+            RTT::log(RTT::Info) << "SharpnessToOff is not supported by the camera" << RTT::endlog();
+    }
+
+    //setting sharpness mode
+    if(_sharpness_mode.value() == "auto")
+    {
+        if(cam_interface->isAttribAvail(camera::enum_attrib::SharpnessModeToAuto))
+            cam_interface->setAttrib(camera::enum_attrib::SharpnessModeToAuto);
+        else
+            RTT::log(RTT::Info) << "SharpnessModeToAuto is not supported by the camera" << RTT::endlog();
+    }
+    else if(_sharpness_mode.value() =="manual")
+    {
+        if(cam_interface->isAttribAvail(camera::enum_attrib::SharpnessModeToManual))
+            cam_interface->setAttrib(camera::enum_attrib::SharpnessModeToManual);
+        else
+            RTT::log(RTT::Info) << "SharpnessModeToManual is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        RTT::log(RTT::Error) << "Sharpness mode "+ _sharpness_mode.value() + " is not supported!" << RTT::endlog();
         report(UNKOWN_PARAMETER);
         return false;
     }
@@ -666,6 +775,18 @@ bool Task::configureCamera()
         cam_interface->setAttrib(camera::int_attrib::GainValue,_gain);
     else
         RTT::log(RTT::Info) << "GainValue is not supported by the camera" << RTT::endlog();
+
+    //setting SaturationValue
+    if(cam_interface->isAttribAvail(int_attrib::SaturationValue))
+        cam_interface->setAttrib(camera::int_attrib::SaturationValue,_saturation);
+    else
+        RTT::log(RTT::Info) << "SaturationValue is not supported by the camera" << RTT::endlog();
+
+    //setting SharpnessValue
+    if(cam_interface->isAttribAvail(int_attrib::SharpnessValue))
+        cam_interface->setAttrib(camera::int_attrib::SharpnessValue,_sharpness);
+    else
+        RTT::log(RTT::Info) << "SharpnessValue is not supported by the camera" << RTT::endlog();
 
     //setting ShutterValue
     if(cam_interface->isAttribAvail(int_attrib::ShutterValue))

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -396,6 +396,28 @@ bool Task::configureCamera()
         return false;
     }
 
+    //setting shutter mode
+    if(_shutter_mode.value() == "auto")
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::ShutterModeToAuto))
+            cam_interface->setAttrib(enum_attrib::ShutterModeToAuto);
+        else
+            RTT::log(RTT::Info) << "ShutterModeToAuto is not supported by the camera" << RTT::endlog();
+    }
+    else if(_shutter_mode.value() == "manual")
+    {
+        if(cam_interface->isAttribAvail(enum_attrib::ShutterModeToManual))
+            cam_interface->setAttrib(enum_attrib::ShutterModeToManual);
+        else
+            RTT::log(RTT::Info) << "ShutterModeToManual is not supported by the camera" << RTT::endlog();
+    }
+    else
+    {
+        RTT::log(RTT::Error) << "Shutter mode "+ _shutter_mode.value() + " is not supported!" << RTT::endlog();
+        report(UNKOWN_PARAMETER);
+        return false;
+    }
+
     //setting _trigger_mode
     if(_trigger_mode.value() == "freerun")
     {
@@ -644,6 +666,12 @@ bool Task::configureCamera()
         cam_interface->setAttrib(camera::int_attrib::GainValue,_gain);
     else
         RTT::log(RTT::Info) << "GainValue is not supported by the camera" << RTT::endlog();
+
+    //setting ShutterValue
+    if(cam_interface->isAttribAvail(int_attrib::ShutterValue))
+        cam_interface->setAttrib(camera::int_attrib::ShutterValue,_shutter_time);
+    else
+        RTT::log(RTT::Info) << "ShutterValue is not supported by the camera" << RTT::endlog();
 
     //setting WhitebalValueBlue
     if(cam_interface->isAttribAvail(int_attrib::WhitebalValueBlue))

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -296,49 +296,6 @@ bool Task::configureCamera()
         cam_interface->setAttrib(camera::int_attrib::TargetGrayValue, _target_gray_value);
     }
 
-    //setting ExposureValue
-    if(cam_interface->isAttribAvail(int_attrib::ExposureValue))
-        cam_interface->setAttrib(camera::int_attrib::ExposureValue,_exposure);
-    else
-        RTT::log(RTT::Info) << "ExposureValue is not supported by the camera" << RTT::endlog();
-
-   
-    //setting GainValue
-    if(cam_interface->isAttribAvail(int_attrib::GainValue))
-        cam_interface->setAttrib(camera::int_attrib::GainValue,_gain);
-    else
-        RTT::log(RTT::Info) << "GainValue is not supported by the camera" << RTT::endlog();
-
-    //setting WhitebalValueBlue
-    if(cam_interface->isAttribAvail(int_attrib::WhitebalValueBlue))
-        cam_interface->setAttrib(camera::int_attrib::WhitebalValueBlue,_whitebalance_blue);
-    else
-        RTT::log(RTT::Info) << "WhitebalValueBlue is not supported by the camera" << RTT::endlog();
-
-    //setting WhitebalValueRed
-    if(cam_interface->isAttribAvail(int_attrib::WhitebalValueRed))
-        cam_interface->setAttrib(camera::int_attrib::WhitebalValueRed,_whitebalance_red);
-    else
-        RTT::log(RTT::Info) << "WhitebalValueRed is not supported by the camera" << RTT::endlog();
-
-    //setting WhitebalAutoRate
-    if(cam_interface->isAttribAvail(int_attrib::WhitebalAutoRate))
-        cam_interface->setAttrib(camera::int_attrib::WhitebalAutoRate,_whitebalance_auto_rate);
-    else
-        RTT::log(RTT::Info) << "WhitebalAutoRate is not supported by the camera" << RTT::endlog();
-
-    //setting WhitebalAutoAdjustTol
-    if(cam_interface->isAttribAvail(int_attrib::WhitebalAutoAdjustTol))
-        cam_interface->setAttrib(camera::int_attrib::WhitebalAutoAdjustTol,_whitebalance_auto_threshold);
-    else
-        RTT::log(RTT::Info) << "WhitebalAutoAdjustTol is not supported by the camera" << RTT::endlog();
-    
-    //setting AcquisitionFrameCount
-    if(cam_interface->isAttribAvail(int_attrib::AcquisitionFrameCount))
-      cam_interface->setAttrib(int_attrib::AcquisitionFrameCount, _acquisition_frame_count);
-    else
-      RTT::log(RTT::Info) << "AcquisitionFrameCount is not supported by the camera" << RTT::endlog();
-
     //setting gamma mode
     if(_gamma.get())
     {
@@ -657,6 +614,50 @@ bool Task::configureCamera()
         report(UNKOWN_PARAMETER);
         return false;
     }
+
+    //setting ExposureValue
+    if(cam_interface->isAttribAvail(int_attrib::ExposureValue))
+        cam_interface->setAttrib(camera::int_attrib::ExposureValue,_exposure);
+    else
+        RTT::log(RTT::Info) << "ExposureValue is not supported by the camera" << RTT::endlog();
+
+   
+    //setting GainValue
+    if(cam_interface->isAttribAvail(int_attrib::GainValue))
+        cam_interface->setAttrib(camera::int_attrib::GainValue,_gain);
+    else
+        RTT::log(RTT::Info) << "GainValue is not supported by the camera" << RTT::endlog();
+
+    //setting WhitebalValueBlue
+    if(cam_interface->isAttribAvail(int_attrib::WhitebalValueBlue))
+        cam_interface->setAttrib(camera::int_attrib::WhitebalValueBlue,_whitebalance_blue);
+    else
+        RTT::log(RTT::Info) << "WhitebalValueBlue is not supported by the camera" << RTT::endlog();
+
+    //setting WhitebalValueRed
+    if(cam_interface->isAttribAvail(int_attrib::WhitebalValueRed))
+        cam_interface->setAttrib(camera::int_attrib::WhitebalValueRed,_whitebalance_red);
+    else
+        RTT::log(RTT::Info) << "WhitebalValueRed is not supported by the camera" << RTT::endlog();
+
+    //setting WhitebalAutoRate
+    if(cam_interface->isAttribAvail(int_attrib::WhitebalAutoRate))
+        cam_interface->setAttrib(camera::int_attrib::WhitebalAutoRate,_whitebalance_auto_rate);
+    else
+        RTT::log(RTT::Info) << "WhitebalAutoRate is not supported by the camera" << RTT::endlog();
+
+    //setting WhitebalAutoAdjustTol
+    if(cam_interface->isAttribAvail(int_attrib::WhitebalAutoAdjustTol))
+        cam_interface->setAttrib(camera::int_attrib::WhitebalAutoAdjustTol,_whitebalance_auto_threshold);
+    else
+        RTT::log(RTT::Info) << "WhitebalAutoAdjustTol is not supported by the camera" << RTT::endlog();
+    
+    //setting AcquisitionFrameCount
+    if(cam_interface->isAttribAvail(int_attrib::AcquisitionFrameCount))
+      cam_interface->setAttrib(int_attrib::AcquisitionFrameCount, _acquisition_frame_count);
+    else
+      RTT::log(RTT::Info) << "AcquisitionFrameCount is not supported by the camera" << RTT::endlog();
+
 
 
     RTT::log(RTT::Info) << "camera configuration: width="<<_width <<


### PR DESCRIPTION
We have new commits for the following reasons:

1) Applying modes before values so that the values are properly configured in the first run if a mode is changed from auto to manual
2) Changing the name of the SHUTTER functionality (which was wrongly called exposure). Now EXPOSURE manages the exposure and SHUTTER the shutter.
3) (Together with the previous 2 reasons) Being able to change mode, value and power (functionality on/off) for the following DC1394 features: exposure, gain, shutter, saturation, sharpness, gamma, white balance.

This pull request depends on the following pull requests:
a) camera_firewire (library)
b) camera_interface