### PR TITLE
do nothing in case of non positive dynamic exposure values

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -884,6 +884,10 @@ void Task::onRetrieveNewFrame(base::samples::frame::Frame& frame)
 
 bool Task::setExposure(int exposure)
 {
+    //do nothing of given non-positive value
+    if(exposure <= 0)
+        return false;
+
     cam_interface->setAttrib(enum_attrib::ExposureModeToManual);
     _exposure_mode.set("manual");
     cam_interface->setAttrib(int_attrib::ExposureValue,exposure);


### PR DESCRIPTION
Prevents the driver crashes in case of an accidental non-positive value is set. 