### PR TITLE
import opencv implicitly from camera_interface

### DIFF
--- a/camera_base.orogen
+++ b/camera_base.orogen
@@ -2,7 +2,7 @@ name 'camera_base'
 
 using_library "frame_helper"
 using_library "camera_interface"
-using_library "opencv"
+
 import_types_from "base"
 import_types_from "frame_helper/Calibration.h"
 import_types_from "frame_helper/FrameHelperTypes.h"


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-drivers/drivers-camera_interface/pull/5

The library does not depend on opencv. camera_interface had it
as a public interface, but the dependency was missing from the
pkg-config file.