### PR TITLE
fix: avoid runtime state update if unchanged

### DIFF
--- a/camera_base.orogen
+++ b/camera_base.orogen
@@ -204,7 +204,6 @@ end
 
 # Task to pre-process images before used by other components
 task_context "Preprocess", subclasses: "Base" do
-    reports :PROCESSING_ERROR
     needs_configuration
     input_port('iframe', ro_ptr('base::samples::frame::Frame'))
     output_port 'oframe', ro_ptr('base::samples::frame::Frame')
@@ -234,6 +233,8 @@ task_context "Preprocess", subclasses: "Base" do
 
     property("offset_y",   "int", 0).
        doc "the offset to be used on the left margin in case of scaling"
+    
+    runtime_states :PROCESSING_ERROR
 
     port_driven
 end

--- a/camera_base.orogen
+++ b/camera_base.orogen
@@ -8,7 +8,14 @@ import_types_from "frame_helper/Calibration.h"
 import_types_from "frame_helper/FrameHelperTypes.h"
 import_types_from "camera_interface/CamTypes.h"
 
-task_context "Task" do
+task_context "Base" do
+    # If threads == 1, OpenCV will disable threading optimizations and run all it's
+    # functions sequentially. Passing threads < 0 will reset threads number to
+    # system default
+    property "opencv_num_threads", "int", -1
+end
+
+task_context "Task", subclasses: "Base" do
     needs_configuration
 
     ###########################################################
@@ -196,7 +203,7 @@ task_context "Task" do
 end
 
 # Task to pre-process images before used by other components
-task_context "Preprocess" do
+task_context "Preprocess", subclasses: "Base" do
     reports :PROCESSING_ERROR
     needs_configuration
     input_port('iframe', ro_ptr('base::samples::frame::Frame'))

--- a/tasks/Base.cpp
+++ b/tasks/Base.cpp
@@ -1,0 +1,51 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "Base.hpp"
+
+#include <opencv2/core/utility.hpp>
+
+using namespace camera_base;
+
+Base::Base(std::string const& name, TaskCore::TaskState initial_state)
+    : BaseBase(name, initial_state)
+{
+}
+
+Base::~Base()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See Base.hpp for more detailed
+// documentation about them.
+
+bool Base::configureHook()
+{
+    if (!BaseBase::configureHook())
+        return false;
+
+    cv::setNumThreads(_opencv_num_threads.get());
+    return true;
+}
+bool Base::startHook()
+{
+    if (!BaseBase::startHook())
+        return false;
+    return true;
+}
+void Base::updateHook()
+{
+    BaseBase::updateHook();
+}
+void Base::errorHook()
+{
+    BaseBase::errorHook();
+}
+void Base::stopHook()
+{
+    BaseBase::stopHook();
+}
+void Base::cleanupHook()
+{
+    BaseBase::cleanupHook();
+}

--- a/tasks/Base.hpp
+++ b/tasks/Base.hpp
@@ -1,0 +1,105 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef CAMERA_BASE_BASE_TASK_HPP
+#define CAMERA_BASE_BASE_TASK_HPP
+
+#include "camera_base/BaseBase.hpp"
+
+namespace camera_base {
+
+    /*! \class Base
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','camera_base::Base')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
+     */
+    class Base : public BaseBase {
+        friend class BaseBase;
+
+    protected:
+    public:
+        /** TaskContext constructor for Base
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
+         */
+        Base(std::string const& name = "camera_base::Base",
+            TaskCore::TaskState initial_state = Stopped);
+
+        /** Default deconstructor of Base
+         */
+        ~Base();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif

--- a/tasks/Preprocess.cpp
+++ b/tasks/Preprocess.cpp
@@ -59,7 +59,9 @@ void Preprocess::updateHook()
     catch(std::runtime_error e)
     {
         RTT::log(RTT::Error) << "processing error: " << e.what() << RTT::endlog();
-        report(PROCESSING_ERROR);
+        if (state() != PROCESSING_ERROR) {
+            state(PROCESSING_ERROR);
+        }
     }
 
     oframe.reset(frame_ptr);


### PR DESCRIPTION
# What is this PR for

Avoid rewriting the runtime state if it is unchanged.
The recurrent state update floods the syskit journalctl
![image](https://github.com/user-attachments/assets/f2dc0b63-94fd-45df-9864-a2b400225bb0)
